### PR TITLE
Use real submissions in gallery

### DIFF
--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,27 +1,74 @@
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { ArrowLeft, Search, Filter } from 'lucide-react';
+import { supabase } from '@/integrations/supabase/client';
 
 interface GalleryProps {
   onNavigate: (page: string) => void;
 }
 
+interface GalleryImage {
+  id: string;
+  image_url: string;
+  title: string;
+  type: string;
+  department?: string | null;
+  club?: string | null;
+}
+
 const Gallery = ({ onNavigate }: GalleryProps) => {
   const [searchTerm, setSearchTerm] = useState('');
-  const [filterType, setFilterType] = useState('all');
+  const [filterType, setFilterType] = useState<'all' | 'department' | 'club'>('all');
+  const [images, setImages] = useState<GalleryImage[]>([]);
+  const [loading, setLoading] = useState(true);
 
-  // Mock data for gallery images
-  const mockImages = [
-    { id: 1, src: '/placeholder.svg', title: 'AI Workshop', type: 'department', department: 'CSE' },
-    { id: 2, src: '/placeholder.svg', title: 'IEEE Event', type: 'club', club: 'IEEE' },
-    { id: 3, src: '/placeholder.svg', title: 'Cultural Fest', type: 'club', club: 'Cultural' },
-    { id: 4, src: '/placeholder.svg', title: 'Research Symposium', type: 'department', department: 'ECE' },
-    { id: 5, src: '/placeholder.svg', title: 'Robotics Competition', type: 'club', club: 'Robotics' },
-    { id: 6, src: '/placeholder.svg', title: 'Faculty Achievement', type: 'department', department: 'ME' }
-  ];
+  useEffect(() => {
+    const fetchImages = async () => {
+      const { data, error } = await supabase
+        .from('submissions')
+        .select(`
+          id,
+          title,
+          type,
+          department,
+          club,
+          submission_images (
+            id,
+            image_url
+          )
+        `)
+        .eq('status', 'approved')
+        .order('created_at', { ascending: false });
+
+      if (error) {
+        console.error('Error fetching images:', error);
+        setLoading(false);
+        return;
+      }
+
+      const loaded: GalleryImage[] = [];
+      (data || []).forEach((submission: any) => {
+        (submission.submission_images || []).forEach((img: any) => {
+          loaded.push({
+            id: img.id,
+            image_url: img.image_url,
+            title: submission.title,
+            type: submission.type,
+            department: submission.department,
+            club: submission.club,
+          });
+        });
+      });
+
+      setImages(loaded);
+      setLoading(false);
+    };
+
+    fetchImages();
+  }, []);
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -64,43 +111,49 @@ const Gallery = ({ onNavigate }: GalleryProps) => {
           </div>
 
           {/* Image Grid */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {mockImages
-              .filter(img => 
-                filterType === 'all' || img.type === filterType
-              )
-              .filter(img =>
-                img.title.toLowerCase().includes(searchTerm.toLowerCase())
-              )
-              .map((image, index) => (
-                <div
-                  key={image.id}
-                  className="group relative overflow-hidden rounded-lg shadow-lg hover:shadow-xl transition-all duration-300 bg-white"
-                  style={{
-                    animationDelay: `${index * 100}ms`
-                  }}
-                >
-                  <div className="aspect-video bg-gray-200 flex items-center justify-center">
-                    <img
-                      src={image.src}
-                      alt={image.title}
-                      className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-                    />
-                  </div>
-                  <div className="p-4">
-                    <h3 className="font-semibold text-gray-900 mb-1">{image.title}</h3>
-                    <p className="text-sm text-gray-600">
-                      {image.type === 'department' ? image.department : image.club}
-                    </p>
-                  </div>
-                </div>
-              ))}
-          </div>
-
-          {mockImages.length === 0 && (
+          {loading ? (
             <div className="text-center py-16">
-              <p className="text-gray-500 text-lg">No images found</p>
+              <p className="text-gray-500 text-lg">Loading...</p>
             </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                {images
+                  .filter(img => filterType === 'all' || img.type === filterType)
+                  .filter(img =>
+                    img.title.toLowerCase().includes(searchTerm.toLowerCase())
+                  )
+                  .map((image, index) => (
+                    <div
+                      key={image.id}
+                      className="group relative overflow-hidden rounded-lg shadow-lg hover:shadow-xl transition-all duration-300 bg-white"
+                      style={{
+                        animationDelay: `${index * 100}ms`
+                      }}
+                    >
+                      <div className="aspect-video bg-gray-200 flex items-center justify-center">
+                        <img
+                          src={image.image_url}
+                          alt={image.title}
+                          className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                        />
+                      </div>
+                      <div className="p-4">
+                        <h3 className="font-semibold text-gray-900 mb-1">{image.title}</h3>
+                        <p className="text-sm text-gray-600">
+                          {image.type === 'department' ? image.department : image.club}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+              </div>
+
+              {images.length === 0 && (
+                <div className="text-center py-16">
+                  <p className="text-gray-500 text-lg">No images found</p>
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove mock image data in the gallery
- fetch approved submission images from Supabase
- display a loading state while fetching

## Testing
- `npm run lint` *(fails: unexpected any errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685118c7ca84832fa7f81a0589067d9b